### PR TITLE
FIX: Compatibility with nibabies

### DIFF
--- a/bin/ASEGDilateUnmWMFix
+++ b/bin/ASEGDilateUnmWMFix
@@ -4,7 +4,7 @@ import numpy
 import sys
 import os
 import nibabel
-import scipy.ndimage.morphology
+import scipy.ndimage
 
 if len(sys.argv) < 4:
     print("Incorrect number of arguments")
@@ -22,10 +22,10 @@ if not os.path.isfile(ASEGFileName):
     quit()
 
 ASEGNII = nibabel.load(ASEGFileName)
-ASEGIMG = ASEGNII.get_data()
+ASEGIMG = numpy.asanyarray(ASEGNII.dataobj)
 
 RibbonNII = nibabel.load(RibbonFileName)
-RibbonIMG = RibbonNII.get_data()
+RibbonIMG = numpy.asanyarray(RibbonNII.dataobj)
 
 NewASEGIMG = numpy.array(ASEGIMG)
 
@@ -38,7 +38,7 @@ NewASEGIMG[numpy.logical_and(CurMyelinatedWMIMG, RibbonIMG == 41)] = 162
 NumDilations = 5
 
 for z in range(NumDilations):
-    CurMyelinatedWMIMG = numpy.logical_and(numpy.logical_or(ASEGIMG == 85, ASEGIMG == 0), scipy.ndimage.morphology.binary_dilation(CurMyelinatedWMIMG))
+    CurMyelinatedWMIMG = numpy.logical_and(numpy.logical_or(ASEGIMG == 85, ASEGIMG == 0), scipy.ndimage.binary_dilation(CurMyelinatedWMIMG))
 
 NewASEGIMG[numpy.logical_and(CurMyelinatedWMIMG, ASEGIMG == 0)] = 24
 

--- a/bin/MCRIBReconAll
+++ b/bin/MCRIBReconAll
@@ -222,10 +222,12 @@ def main():
     # get ITK version
     # find ITKConfig.cmake in scriptPath/ITK/ITK-install
 
-    os.chdir(os.path.join(scriptPath, '..', 'ITK', 'ITK'))
-
-    gitProcess = subprocess.run(['git', 'rev-parse', 'HEAD'], stdout = subprocess.PIPE)
-    ITKGitHash = gitProcess.stdout.decode("utf-8").rstrip()
+    try:
+        os.chdir(os.path.join(scriptPath, '..', 'ITK', 'ITK'))
+        gitProcess = subprocess.run(['git', 'rev-parse', 'HEAD'], stdout = subprocess.PIPE)
+        ITKGitHash = gitProcess.stdout.decode("utf-8").rstrip()
+    except Exception:
+        ITKGitHash = "n/a"
     logFileFID.write("ITK version\n")
     logFileFID.write('ITK git revision: ' + ITKGitHash + "\n")
 
@@ -268,11 +270,12 @@ def main():
 
 
     # get VTK version
-    os.chdir(os.path.join(scriptPath, '..', 'VTK', 'VTK'))
-
-    gitProcess = subprocess.run(['git', 'rev-parse', 'HEAD'], stdout = subprocess.PIPE)
-    VTKGitHash = gitProcess.stdout.decode("utf-8").rstrip()
-
+    try:
+        os.chdir(os.path.join(scriptPath, '..', 'VTK', 'VTK'))
+        gitProcess = subprocess.run(['git', 'rev-parse', 'HEAD'], stdout = subprocess.PIPE)
+        VTKGitHash = gitProcess.stdout.decode("utf-8").rstrip()
+    except Exception:
+        VTKGitHash = "n/a"
     logFileFID.write("VTK version\n")
     logFileFID.write('VTK git revision: ' + VTKGitHash + "\n")
 

--- a/bin/MCRIBVolMask
+++ b/bin/MCRIBVolMask
@@ -8,14 +8,23 @@ fi
 
 SUBJID=$1
 
+MCRIB_BIN=$(dirname $0)
 export SUBJECTS_DIR=`pwd`/freesurfer
-cd $SUBJECTS_DIR/$SUBJID/mri
+SUBJ_MRI_DIR=$SUBJECTS_DIR/$SUBJID/mri
+mkdir -p $SUBJ_MRI_DIR
+cd $SUBJ_MRI_DIR
 
-if [ -f "aseg.presurf.preunwmfix.mgz" ]
-then
+if [ -f "aseg.presurf.preunwmfix.mgz" ]; then
 	ASEGFILE=aseg.presurf.preunwmfix
-else
+elif [ -f "aseg.presurf.mgz" ]; then
 	ASEGFILE=aseg.presurf
+else
+    # Create ASEG
+    echo "No aseg found, creating..."
+    ASEGFILE=aseg.presurf.preunwmfix
+    SEGFILE="../../../TissueSeg/${SUBJID}_all_labels_manedit.nii.gz"
+    $MCRIB_BIN/DrawEMToFreesurferLabels $SEGFILE $ASEGFILE.mgz
+    echo "Successfully created aseg"
 fi
 
 if [ ! -f "${ASEGFILE}.mgz" ]
@@ -46,5 +55,5 @@ fi
 if [ "$ASEGFILE" == "aseg.presurf.preunwmfix" ]
 then
 	echo "Running DrawEM fix"
-	ASEGDilateUnmWMFix $ASEGFILE.mgz ribbon.mgz aseg.presurf.mgz
+	$MCRIB_BIN/../VTK/VTK-install/bin/vtkpython $MCRIB_BIN/ASEGDilateUnmWMFix $ASEGFILE.mgz ribbon.mgz aseg.presurf.mgz
 fi


### PR DESCRIPTION
Some minor changes to be compatible with the nibabies build:
- updates to the nibabel / scipy code to avoid deprecations
- wrap ITK/VTK git revision parsing in try / except in cases where the source was deleted
- Add aseg conversion to `MCRIBVolMask` to catch cases where the `MCRIBTissueSegDrawEM` was skipped

I don't think these are breaking changes