### PR TITLE
FIX: Finalize nibabies use case

### DIFF
--- a/bin/APARC2ASEGCSFRestoreDrawEM
+++ b/bin/APARC2ASEGCSFRestoreDrawEM
@@ -30,8 +30,8 @@ if not os.path.isfile(DrawEMLabelsFileName):
 ASEGNII = nibabel.load(ASEGFileName)
 DrawEMLabelsNII = nibabel.load(DrawEMLabelsFileName)
 
-ASEGIMG = ASEGNII.get_data()
-DrawEMLabelsIMG = DrawEMLabelsNII.get_data()
+ASEGIMG = numpy.asanyarray(ASEGNII.dataobj)
+DrawEMLabelsIMG = numpy.asanyarray(DrawEMLabelsNII.dataobj)
 
 NewASEGIMG = numpy.array(ASEGIMG)
 

--- a/bin/MCRIBSegStatsPython
+++ b/bin/MCRIBSegStatsPython
@@ -67,18 +67,18 @@ CTABTable.index.name = 'SegId'
 CTABTable = CTABTable.loc[CTABTable.index > 0]
 
 ASEGNII = nibabel.load(ASEGFileName)
-ASEGIMG = ASEGNII.get_data()
+ASEGIMG = numpy.asanyarray(ASEGNII.dataobj)
 
 voxelSize = numpy.prod(ASEGNII.header.get_zooms())
 
 T2NII = nibabel.load(T2IMGFileName)
-T2IMG = T2NII.get_data()
+T2IMG = numpy.asanyarray(T2NII.dataobj)
 
 RibbonNII = nibabel.load(RibbonIMGFileName)
-RibbonIMG = RibbonNII.get_data()
+RibbonIMG = numpy.asanyarray(RibbonNII.dataobj)
 
 BrainmaskNII = nibabel.load(BrainmaskIMGFileName)
-BrainmaskIMG = BrainmaskNII.get_data()
+BrainmaskIMG = numpy.asanyarray(BrainmaskNII.dataobj)
 
 doingLabelTable = False
 

--- a/bin/MCRIBVolMask
+++ b/bin/MCRIBVolMask
@@ -57,3 +57,27 @@ then
 	echo "Running DrawEM fix"
 	$MCRIB_BIN/../VTK/VTK-install/bin/vtkpython $MCRIB_BIN/ASEGDilateUnmWMFix $ASEGFILE.mgz ribbon.mgz aseg.presurf.mgz
 fi
+
+if [ ! -f "T2.mgz" ]; then
+    echo "Creating missing FreeSurfer T2"
+    # T2w.mgz  was not created by MCRIBTissueSegDrawEM
+    mri_convert ../../../RawT2RadiologicalIsotropic/${SUBJID}.nii.gz T2.mgz
+    if [ ! -f orig.mgz ]; then
+        ln -sf T2.mgz orig.mgz
+    fi
+
+    if [ ! -f brain.mgz ]; then
+        ln -sf T2.mgz brain.mgz
+    fi
+fi
+
+if [ ! -f "norm.mgz" ]; then
+    echo "Creating missing FreeSurfer norm"
+    mri_convert ../../../TissueSegDrawEM/$SUBJID/N4/${SUBJID}.nii.gz norm.mgz
+fi
+
+if [ ! -f "brainmask.mgz" ]; then
+    echo "Creating missing FreeSurfer brainmask"
+    # brainmask.mgz was not created by MCRIBSTissueSegDrawEM
+    mri_mask T2.mgz ../../../TissueSeg/${SUBJID}_brain_mask.nii.gz brainmask.mgz
+fi


### PR DESCRIPTION
Upon further inspection, there were some outstanding errors failing silently, this PR address:
- outstanding nibabel deprecation updates
- produces the necessary freesurfer files for seg/parc stats

@AidanWUSTL this should be the last one - if it looks good, would you mind cutting another release (or updating the existing one)? Thanks!